### PR TITLE
Force "main environments" deploy

### DIFF
--- a/docker-entrypoint.d/05-initialize-code.sh
+++ b/docker-entrypoint.d/05-initialize-code.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-r10k deploy environment -pv
+if [ -n $MAIN_ENVIRONMENTS ]; then
+  for env in $(echo $MAIN_ENVIRONMENTS | tr ',' "\n"); do
+    echo r10k deploy environment $env -pv
+  done
+fi
+echo r10k deploy environment -pv


### PR DESCRIPTION
r10k takes git branches in alphabetical order, stable4 and staging4 are
in the end of the list, hence it might take a looong time before a PM is
"really" up. Deploying first stable4, then staging4, then "the rest"
should help a bit.
